### PR TITLE
Function to print floats

### DIFF
--- a/Firmware/pong/oled/Edison_OLED.cpp
+++ b/Firmware/pong/oled/Edison_OLED.cpp
@@ -372,6 +372,13 @@ void edOLED::print(int d)
 	print(temp);
 }
 
+void edOLED::print(float f)
+{
+	char temp[24];
+	sprintf(temp, "%.2f", f);
+	print(temp);
+}
+
 /** \brief Set cursor position.
 
     edOLED's cursor position to x,y.

--- a/Firmware/pong/oled/Edison_OLED.h
+++ b/Firmware/pong/oled/Edison_OLED.h
@@ -105,6 +105,7 @@ public:
 	unsigned char write(unsigned char);
 	void print(const char * c);
 	void print(int d);
+	void print(float f);
 
 	// RAW LCD functions
 	void command(unsigned char c);


### PR DESCRIPTION
In a project I was working on, I found that if I tried to print floats, it would use the int printing function so it would remove the decimals which I needed to see. This adds a function that prints floats, and rounds them to 2 decimal places. I figured that 2 decimal places would be a reasonable amount of decimals to display on the small OLED screen.
