### PR TITLE
Fixed C++ library interference issue

### DIFF
--- a/Firmware/pong/oled/Edison_OLED.cpp
+++ b/Firmware/pong/oled/Edison_OLED.cpp
@@ -432,14 +432,14 @@ void edOLED::line(unsigned char x0, unsigned char y0, unsigned char x1, unsigned
 	unsigned char steep = abs(y1 - y0) > abs(x1 - x0);
 	if (steep)
 	{
-		swap(x0, y0);
-		swap(x1, y1);
+		swapOLED(x0, y0);
+		swapOLED(x1, y1);
 	}
 
 	if (x0 > x1)
 	{
-		swap(x0, x1);
-		swap(y0, y1);
+		swapOLED(x0, x1);
+		swapOLED(y0, y1);
 	}
 
 	unsigned char dx, dy;

--- a/Firmware/pong/oled/Edison_OLED.h
+++ b/Firmware/pong/oled/Edison_OLED.h
@@ -26,7 +26,7 @@
 #ifndef EDISON_OLED_H
 #define EDISON_OLED_H
 
-#define swap(a, b) { unsigned char t = a; a = b; b = t; }
+#define swapOLED(a, b) { unsigned char t = a; a = b; b = t; }
 
 #define BLACK 0
 #define WHITE 1


### PR DESCRIPTION
Having the macro named "swap" interferes with other C++ libraries, such as sstream, which use a macro with the same name.   
